### PR TITLE
fix roi_align precesion bug

### DIFF
--- a/mmcv/ops/csrc/pytorch/npu/roi_align_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/roi_align_npu.cpp
@@ -7,14 +7,14 @@ void roi_align_forward_npu(Tensor input, Tensor rois, Tensor output,
                            Tensor argmax_y, Tensor argmax_x, int aligned_height,
                            int aligned_width, float spatial_scale,
                            int sampling_ratio, int pool_mode, bool aligned) {
-  int64_t roi_end_mode = 2;
+  int64_t aligned_height_64 = aligned_height;
+  int64_t aligned_width_64 = aligned_width;
+  int64_t sampling_ratio_64 = sampling_ratio;
+  int64_t roi_end_mode = 3;
   if (!aligned) {
     LOG(WARNING) << "The [aligned] attr in roi_align op is false";
     roi_end_mode = 0;
   }
-  int64_t aligned_height_64 = aligned_height;
-  int64_t aligned_width_64 = aligned_width;
-  int64_t sampling_ratio_64 = sampling_ratio;
   OpCommand cmd;
   cmd.Name("ROIAlign")
       .Input(input)
@@ -36,7 +36,7 @@ void roi_align_backward_npu(Tensor grad_output, Tensor rois, Tensor argmax_y,
   int64_t aligned_height_64 = aligned_height;
   int64_t aligned_width_64 = aligned_width;
   int64_t sampling_ratio_64 = sampling_ratio;
-  int64_t roi_end_mode = 2;
+  int64_t roi_end_mode = 3;
   if (!aligned) {
     LOG(WARNING) << "The [aligned] attr in roi_align_grad op is false";
     roi_end_mode = 0;


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This PR fixes a precesion bug for `roi_align`. when the attritube `aligned=True`, the parameter `roi_end_mode` passed to the `NPU` kernel shoule be `3` .

## Modification

This PR changes the default value of `roi_end_mode` from `2` to `3`.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
