### PR TITLE
Add dtype check for roi_align

### DIFF
--- a/mmcv/ops/csrc/pytorch/npu/chamfer_distance_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/chamfer_distance_npu.cpp
@@ -5,19 +5,34 @@ using namespace std;
 
 void chamfer_distance_forward_npu(Tensor XYZ1, Tensor XYZ2, Tensor dist1,
                                   Tensor dist2, Tensor idx1, Tensor idx2) {
+  bool is_half = input.scalar_type() == at::kHalf;
   at::Tensor xyz1 = at::ones_like(XYZ1);
   at::Tensor xyz2 = at::ones_like(XYZ2);
+  at::Tensor distf1 = at::ones_like(dist1);
+  at::Tensor distf2 = at::ones_like(dist2);
   xyz1 = XYZ1.transpose(1, 2).transpose(0, 1);
   xyz2 = XYZ2.transpose(1, 2).transpose(0, 1);
+  if (is_half) {
+    xyz1 = xyz1.to(at::kFloat);
+    xyz2 = xyz2.to(at::kFloat);
+    distf1 = dist1.to(at::kFloat);
+    distf2 = dist2.to(at::kFloat);
+  }
   OpCommand cmd;
   cmd.Name("ChamferDistance")
       .Input(xyz1)
       .Input(xyz2)
-      .Output(dist1)
-      .Output(dist2)
+      .Output(distf1)
+      .Output(distf2)
       .Output(idx1)
       .Output(idx2)
       .Run();
+  if (is_half) {
+    distf1 = distf1.to(at::kHalf);
+    distf2 = distf2.to(at::kHalf);
+  }
+  dist1.copy_(distf1);
+  dist2.copy_(distf2);
 }
 
 void chamfer_distance_backward_npu(Tensor xyz1, Tensor xyz2, Tensor idx1,

--- a/mmcv/ops/csrc/pytorch/npu/chamfer_distance_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/chamfer_distance_npu.cpp
@@ -5,7 +5,7 @@ using namespace std;
 
 void chamfer_distance_forward_npu(Tensor XYZ1, Tensor XYZ2, Tensor dist1,
                                   Tensor dist2, Tensor idx1, Tensor idx2) {
-  bool is_half = input.scalar_type() == at::kHalf;
+  bool is_half = XYZ1.scalar_type() == at::kHalf;
   at::Tensor xyz1 = at::ones_like(XYZ1);
   at::Tensor xyz2 = at::ones_like(XYZ2);
   at::Tensor distf1 = at::ones_like(dist1);

--- a/mmcv/ops/csrc/pytorch/npu/gather_points_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/gather_points_npu.cpp
@@ -80,8 +80,8 @@ void gather_points_forward_impl(int b, int c, int n, int npoints,
                                 const Tensor points, const Tensor idx,
                                 Tensor out);
 void gather_points_backward_impl(int b, int c, int n, int npoints,
-                                const Tensor grad_out, const Tensor idx,
-                                Tensor grad_points);
+                                 const Tensor grad_out, const Tensor idx,
+                                 Tensor grad_points);
 
 REGISTER_NPU_IMPL(gather_points_forward_impl, gather_points_forward_npu);
 REGISTER_NPU_IMPL(gather_points_backward_impl, gather_points_backward_npu);

--- a/mmcv/ops/csrc/pytorch/npu/gather_points_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/gather_points_npu.cpp
@@ -27,8 +27,8 @@ void gather_points_backward_npu(int b, int c, int n, int npoints,
   at::Tensor grad_out_cast = grad_out;
   at::Tensor grad_points_cast = grad_points;
   if (grad_out.scalar_type() == at::ScalarType::Half) {
-    grad_out_cast = at_npu::native::custom_ops::npu_dtype_cast(grad_out, at::ScalarType::Float);
-    grad_points_cast = at_npu::native::custom_ops::npu_dtype_cast(grad_points, at::ScalarType::Float);
+    grad_out_cast = grad_out.to(at::kFloat);
+    grad_points_cast = grad_points.to(at::kFloat);
   }
   at::Tensor indices = idx;
   if (idx.scalar_type() != at::ScalarType::Int) {
@@ -71,7 +71,7 @@ void gather_points_backward_npu(int b, int c, int n, int npoints,
   grad_points_result = grad_points_result.transpose(1, 2);
   at::Tensor grad_points_result_cast = grad_points_result;
   if (grad_out.scalar_type() == at::ScalarType::Half) {
-    grad_points_result_cast = at_npu::native::custom_ops::npu_dtype_cast(grad_points_result, at::ScalarType::Float);
+    grad_points_result_cast = grad_points_result.to(at::kHalf);
   }
   grad_points.copy_(grad_points_result_cast);
 }
@@ -79,5 +79,9 @@ void gather_points_backward_npu(int b, int c, int n, int npoints,
 void gather_points_forward_impl(int b, int c, int n, int npoints,
                                 const Tensor points, const Tensor idx,
                                 Tensor out);
+void gather_points_backward_impl(int b, int c, int n, int npoints,
+                                const Tensor grad_out, const Tensor idx,
+                                Tensor grad_points);
 
 REGISTER_NPU_IMPL(gather_points_forward_impl, gather_points_forward_npu);
+REGISTER_NPU_IMPL(gather_points_backward_impl, gather_points_backward_npu);

--- a/mmcv/ops/csrc/pytorch/npu/gather_points_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/gather_points_npu.cpp
@@ -24,6 +24,12 @@ void gather_points_forward_npu(int b, int c, int n, int npoints,
 void gather_points_backward_npu(int b, int c, int n, int npoints,
                                 const Tensor grad_out, const Tensor idx,
                                 Tensor grad_points) {
+  at::Tensor grad_out_cast = grad_out;
+  at::Tensor grad_points_cast = grad_points;
+  if (grad_out.scalar_type() == at::ScalarType::Half) {
+    grad_out_cast = at_npu::native::custom_ops::npu_dtype_cast(grad_out, at::ScalarType::Float);
+    grad_points_cast = at_npu::native::custom_ops::npu_dtype_cast(grad_points, at::ScalarType::Float);
+  }
   at::Tensor indices = idx;
   if (idx.scalar_type() != at::ScalarType::Int) {
     indices = idx.to(at::kInt);
@@ -37,11 +43,11 @@ void gather_points_backward_npu(int b, int c, int n, int npoints,
   for (uint64_t i = 0; i < shape.size(); i++) {
     pad_size.emplace_back(shape[i]);
   }
-  at::Tensor trans_grad_points = grad_points.transpose(1, 2).contiguous();
+  at::Tensor trans_grad_points = grad_points_cast.transpose(1, 2).contiguous();
   at::Tensor grad_points_view = trans_grad_points.view(
       {trans_grad_points.sizes()[0] * trans_grad_points.sizes()[1],
        trans_grad_points.sizes()[2]});
-  at::Tensor trans_grad_out = grad_out.transpose(1, 2).contiguous();
+  at::Tensor trans_grad_out = grad_out_cast.transpose(1, 2).contiguous();
   trans_grad_out = trans_grad_out.view(
       {trans_grad_out.sizes()[0] * trans_grad_out.sizes()[1],
        trans_grad_out.sizes()[2]});
@@ -63,15 +69,15 @@ void gather_points_backward_npu(int b, int c, int n, int npoints,
   at::Tensor grad_points_result =
       grad_points_view.view(trans_grad_points.sizes());
   grad_points_result = grad_points_result.transpose(1, 2);
-  grad_points.copy_(grad_points_result);
+  at::Tensor grad_points_result_cast = grad_points_result;
+  if (grad_out.scalar_type() == at::ScalarType::Half) {
+    grad_points_result_cast = at_npu::native::custom_ops::npu_dtype_cast(grad_points_result, at::ScalarType::Float);
+  }
+  grad_points.copy_(grad_points_result_cast);
 }
 
 void gather_points_forward_impl(int b, int c, int n, int npoints,
                                 const Tensor points, const Tensor idx,
                                 Tensor out);
-void gather_points_backward_impl(int b, int c, int n, int npoints,
-                                 const Tensor grad_out, const Tensor idx,
-                                 Tensor grad_points);
 
 REGISTER_NPU_IMPL(gather_points_forward_impl, gather_points_forward_npu);
-REGISTER_NPU_IMPL(gather_points_backward_impl, gather_points_backward_npu);

--- a/mmcv/ops/csrc/pytorch/npu/knn_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/knn_npu.cpp
@@ -1,0 +1,21 @@
+#include "pytorch_npu_helper.hpp"
+#include "torch_npu/csrc/aten/NPUNativeFunctions.h"
+#include "torch_npu/csrc/framework/utils/OpAdapter.h"
+
+using namespace NPU_NAME_SPACE;
+using namespace std;
+
+void knn_forward_npu(int b, int n, int m, int nsample, const Tensor xyz,
+                     const Tensor new_xyz, Tensor idx, Tensor dist2) {
+  // transpose known from [B, N, 3] to [B, 3, N]
+  at::Tensor source = xyz.transpose(2, 1).contiguous();
+  at::Tensor target = new_xyz.contiguous();
+
+  bool is_from_knn = true;
+  EXEC_NPU_CMD(aclnnKnn, source, target, is_from_knn, dist2);
+}
+
+void knn_forward_impl(int b, int n, int m, int nsample, const Tensor xyz,
+                      const Tensor new_xyz, Tensor idx, Tensor dist2);
+
+REGISTER_NPU_IMPL(knn_forward_impl, knn_forward_npu);

--- a/mmcv/ops/csrc/pytorch/npu/roi_align_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/roi_align_npu.cpp
@@ -7,14 +7,15 @@ void roi_align_forward_npu(Tensor input, Tensor rois, Tensor output,
                            Tensor argmax_y, Tensor argmax_x, int aligned_height,
                            int aligned_width, float spatial_scale,
                            int sampling_ratio, int pool_mode, bool aligned) {
+  TORCH_CHECK(input.scalar_type() == at::kFloat, "roi_align only support fp32");
+  int64_t aligned_height_64 = aligned_height;
+  int64_t aligned_width_64 = aligned_width;
+  int64_t sampling_ratio_64 = sampling_ratio;
   int64_t roi_end_mode = 2;
   if (!aligned) {
     LOG(WARNING) << "The [aligned] attr in roi_align op is false";
     roi_end_mode = 0;
   }
-  int64_t aligned_height_64 = aligned_height;
-  int64_t aligned_width_64 = aligned_width;
-  int64_t sampling_ratio_64 = sampling_ratio;
   OpCommand cmd;
   cmd.Name("ROIAlign")
       .Input(input)
@@ -33,6 +34,7 @@ void roi_align_backward_npu(Tensor grad_output, Tensor rois, Tensor argmax_y,
                             int aligned_height, int aligned_width,
                             float spatial_scale, int sampling_ratio,
                             int pool_mode, bool aligned) {
+  TORCH_CHECK(grad_output.scalar_type() == at::kFloat, "roi_align_backward only support fp32");
   int64_t aligned_height_64 = aligned_height;
   int64_t aligned_width_64 = aligned_width;
   int64_t sampling_ratio_64 = sampling_ratio;

--- a/mmcv/ops/csrc/pytorch/npu/roi_pool_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/roi_pool_npu.cpp
@@ -50,23 +50,28 @@ void roi_pool_backward_npu(Tensor grad_output, Tensor rois, Tensor argmax,
   int64_t pooled_height_64 = pooled_height;
   int64_t pooled_width_64 = pooled_width;
   int64_t pooled_channel = 1;
+  at::Tensor argmax_trans = argmax.transpose(1, 2).transpose(2, 3);
+  at::Tensor grad_output_trans = grad_output.transpose(1, 2).transpose(2, 3);
   at::Tensor roi_actual_num =
       at::empty_like(rois, rois.options().dtype(at::kInt));
-  at::Tensor x = at::ones_like(grad_input);
+  at::Tensor x = at::ones_like(grad_input).transpose(1, 2).transpose(2, 3);
+  at::Tensor y = at::zeros_like(x);
   OpCommand cmd;
   cmd.Name("RoiPoolingGradWithArgMax")
-      .Input(grad_output)
+      .Input(grad_output_trans)
       .Input(x)
       .Input(rois)
       .Input(roi_actual_num)
-      .Input(argmax)
-      .Output(grad_input)
+      .Input(argmax_trans)
+      .Output(y)
       .Attr("pooled_h", pooled_height_64)
       .Attr("pooled_w", pooled_width_64)
       .Attr("spatial_scale_h", spatial_scale)
       .Attr("spatial_scale_w", spatial_scale)
       .Attr("pool_channel", pooled_channel)
       .Run();
+  at::Tensor res = NpuUtils::format_contiguous(result);
+  grad_input.copy_(res);
 }
 
 void roi_pool_forward_impl(Tensor input, Tensor rois, Tensor output,

--- a/mmcv/ops/csrc/pytorch/npu/roi_pool_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/roi_pool_npu.cpp
@@ -70,7 +70,7 @@ void roi_pool_backward_npu(Tensor grad_output, Tensor rois, Tensor argmax,
       .Attr("spatial_scale_w", spatial_scale)
       .Attr("pool_channel", pooled_channel)
       .Run();
-  at::Tensor res = NpuUtils::format_contiguous(result);
+  at::Tensor res = y.contiguous();
   grad_input.copy_(res);
 }
 

--- a/mmcv/ops/csrc/pytorch/npu/roi_pool_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/roi_pool_npu.cpp
@@ -70,7 +70,8 @@ void roi_pool_backward_npu(Tensor grad_output, Tensor rois, Tensor argmax,
       .Attr("spatial_scale_w", spatial_scale)
       .Attr("pool_channel", pooled_channel)
       .Run();
-  at::Tensor res = y.contiguous();
+  at::Tensor result = y.transpose(2, 3).transpose(1, 2);
+  at::Tensor res = result.contiguous();
   grad_input.copy_(res);
 }
 

--- a/mmcv/ops/csrc/pytorch/npu/stack_ball_query_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/stack_ball_query_npu.cpp
@@ -8,9 +8,10 @@ void stack_ball_query_forward_npu(float max_radius, int nsample,
                                   const Tensor new_xyz_batch_cnt,
                                   const Tensor xyz, const Tensor xyz_batch_cnt,
                                   Tensor idx) {
-  at::Tensor xyz_transpose = xyz.transpose(0, 1).contiguous();
+  at::Tensor xyz_transpose = xyz.transpose(0, 1).contiguous().to(at::kFloat);
+  at::Tensor new_xyz_fp32 = new_xyz.to(at::kFloat);
   double max_radius_double = double(max_radius);
-  EXEC_NPU_CMD(aclnnStackBallQuery, xyz_transpose, new_xyz, xyz_batch_cnt,
+  EXEC_NPU_CMD(aclnnStackBallQuery, xyz_transpose, new_xyz_fp32, xyz_batch_cnt,
                new_xyz_batch_cnt, max_radius_double, nsample, idx);
 }
 

--- a/mmcv/ops/csrc/pytorch/npu/three_interpolate_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/three_interpolate_npu.cpp
@@ -47,7 +47,6 @@ void three_interpolate_backward_npu(int b, int c, int n, int m,
   auto output = at::squeeze(grad_y_cast, 3);
   auto res = output.contiguous();
   grad_points.copy_(res);
-
 }
 
 void three_interpolate_forward_impl(int b, int c, int m, int n,

--- a/mmcv/ops/csrc/pytorch/npu/three_interpolate_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/three_interpolate_npu.cpp
@@ -12,17 +12,21 @@ void three_interpolate_forward_npu(int b, int c, int m, int n,
   TORCH_CHECK((originDtype == at::kFloat || originDtype == at::kHalf),
               "three_interpolate_forward ascend only support fp32 and fp16.");
 
-  auto point_c_trans = points.transpose(1, 2);
-
+  auto point_c_trans = points.transpose(1, 2).to(at::kFloat);
+  auto weight_cast = weight.to(at::kFloat);
+  auto out_cast = out.to(at::kFloat);
   OpCommand cmd;
   cmd.Name("ThreeInterpolate")
       .Input(point_c_trans)
       .Input(idx)
-      .Input(weight)
-      .Output(out)
+      .Input(weight_cast)
+      .Output(out_cast)
       .Run();
 
-  auto output = out.view({b, n, c}).transpose(1, 2);
+  if (originDtype == at::kHalf) {
+    out_cast = out_cast.to(at::kHalf);
+  }
+  auto output = out_cast.view({b, n, c}).transpose(1, 2);
   auto res = output.contiguous();
   out.copy_(res);
 }

--- a/mmcv/ops/csrc/pytorch/npu/three_nn_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/three_nn_npu.cpp
@@ -1,0 +1,20 @@
+#include "pytorch_npu_helper.hpp"
+#include "torch_npu/csrc/aten/NPUNativeFunctions.h"
+#include "torch_npu/csrc/framework/utils/OpAdapter.h"
+
+using namespace NPU_NAME_SPACE;
+using namespace std;
+
+void three_nn_forward_npu(int b, int n, int m, const Tensor unknown,
+                          const Tensor known, Tensor dist2, Tensor idx) {
+  at::Tensor source = known.contiguous();
+  at::Tensor target = unknown.contiguous();
+
+  bool is_from_knn = false;
+  EXEC_NPU_CMD(aclnnKnn, source, target, is_from_knn, dist2);
+}
+
+void three_nn_forward_impl(int b, int n, int m, const Tensor unknown,
+                           const Tensor known, Tensor dist2, Tensor idx);
+
+REGISTER_NPU_IMPL(three_nn_forward_impl, three_nn_forward_npu);

--- a/mmcv/ops/fused_bias_leakyrelu.py
+++ b/mmcv/ops/fused_bias_leakyrelu.py
@@ -258,7 +258,7 @@ def fused_bias_leakyrelu(input: torch.Tensor,
         torch.Tensor: Feature map after non-linear activation.
     """
 
-    if not input.is_cuda:
+    if not input.is_cuda and input.device.type != 'npu':
         return bias_leakyrelu_ref(input, bias, negative_slope, scale)
 
     return FusedBiasLeakyReLUFunction.apply(input, bias.to(input.dtype),

--- a/mmcv/ops/knn.py
+++ b/mmcv/ops/knn.py
@@ -55,11 +55,22 @@ class KNN(Function):
         center_xyz_device = center_xyz.get_device()
         assert center_xyz_device == xyz.get_device(), \
             'center_xyz and xyz should be put on the same device'
-        if torch.cuda.current_device() != center_xyz_device:
-            torch.cuda.set_device(center_xyz_device)
+        if xyz.device.type != 'npu':
+            if torch.cuda.current_device() != center_xyz_device:
+                torch.cuda.set_device(center_xyz_device)
 
         B, npoint, _ = center_xyz.shape
         N = xyz.shape[1]
+
+        if xyz.device.type == 'npu':
+            dist = center_xyz.new_zeros((B, npoint, N)).float()
+            ext_module.knn_forward(
+                xyz, center_xyz, torch.Tensor([]).npu(), dist, b=B, n=N, m=npoint, nsample=k)
+            dist2, idx = torch.topk(dist, k, dim=2, largest=False, sorted=True)
+            zeros_idx = torch.zeros(xyz.shape[0], center_xyz.shape[1], k, dtype=torch.int32).npu()
+            idx.where(dist2 >= 1e10, zeros_idx)
+            idx = idx.transpose(2, 1).contiguous() # [B, k, npoint]
+            return idx.type(torch.IntTensor)
 
         idx = center_xyz.new_zeros((B, npoint, k)).int()
         dist2 = center_xyz.new_zeros((B, npoint, k)).float()

--- a/mmcv/ops/knn.py
+++ b/mmcv/ops/knn.py
@@ -65,12 +65,20 @@ class KNN(Function):
         if xyz.device.type == 'npu':
             dist = center_xyz.new_zeros((B, npoint, N)).float()
             ext_module.knn_forward(
-                xyz, center_xyz, torch.Tensor([]).npu(), dist, b=B, n=N, m=npoint, nsample=k)
+                xyz,
+                center_xyz,
+                torch.Tensor([]).npu(),
+                dist,
+                b=B,
+                n=N,
+                m=npoint,
+                nsample=k)
             dist2, idx = torch.topk(dist, k, dim=2, largest=False, sorted=True)
-            zeros_idx = torch.zeros(xyz.shape[0], center_xyz.shape[1], k, dtype=torch.int32).npu()
+            zeros_idx = torch.zeros(
+                xyz.shape[0], center_xyz.shape[1], k, dtype=torch.int32).npu()
             idx.where(dist2 >= 1e10, zeros_idx)
-            idx = idx.transpose(2, 1).contiguous() # [B, k, npoint]
-            return idx.type(torch.IntTensor)
+            idx = idx.transpose(2, 1).contiguous()  # [B, k, npoint]
+            return idx.int()
 
         idx = center_xyz.new_zeros((B, npoint, k)).int()
         dist2 = center_xyz.new_zeros((B, npoint, k)).float()

--- a/mmcv/ops/nms.py
+++ b/mmcv/ops/nms.py
@@ -405,7 +405,7 @@ def nms_rotated(dets: Tensor,
         flip_mat[-1] = -1
         dets_cw = dets * flip_mat
     else:
-        dets_cw = dets
+        dets_cw = dets.clone()
     multi_label = labels is not None
     if labels is None:
         input_labels = scores.new_empty(0, dtype=torch.int)
@@ -415,6 +415,8 @@ def nms_rotated(dets: Tensor,
         order = scores.new_empty(0, dtype=torch.long)
         if dets.device.type == 'npu':
             coefficient = 57.29578  # 180 / PI
+            dets_cw = dets_cw.float()
+            scores = scores.float()
             for i in range(dets.size()[0]):
                 dets_cw[i][4] *= coefficient  # radians to angle
         keep_inds = ext_module.nms_rotated(dets_cw, scores, order, dets_cw,

--- a/mmcv/ops/points_in_boxes.py
+++ b/mmcv/ops/points_in_boxes.py
@@ -47,8 +47,9 @@ def points_in_boxes_part(points: Tensor, boxes: Tensor) -> Tensor:
     points_device = points.get_device()
     assert points_device == boxes.get_device(), \
         'Points and boxes should be put on the same device'
-    if torch.cuda.current_device() != points_device:
-        torch.cuda.set_device(points_device)
+    if points.device.type != 'npu':
+        if torch.cuda.current_device() != points_device:
+            torch.cuda.set_device(points_device)
 
     ext_module.points_in_boxes_part_forward(boxes.contiguous(),
                                             points.contiguous(),

--- a/mmcv/ops/points_in_boxes.py
+++ b/mmcv/ops/points_in_boxes.py
@@ -51,7 +51,7 @@ def points_in_boxes_part(points: Tensor, boxes: Tensor) -> Tensor:
         if torch.cuda.current_device() != points_device:
             torch.cuda.set_device(points_device)
     elif points.device.type == 'npu':
-        boxes[:, :, 2] += boxes[:, :, 5]
+        boxes[:, :, 2] += boxes[:, :, 5] / 2.0
 
     ext_module.points_in_boxes_part_forward(boxes.contiguous(),
                                             points.contiguous(),

--- a/mmcv/ops/points_in_boxes.py
+++ b/mmcv/ops/points_in_boxes.py
@@ -50,6 +50,8 @@ def points_in_boxes_part(points: Tensor, boxes: Tensor) -> Tensor:
     if points.device.type != 'npu':
         if torch.cuda.current_device() != points_device:
             torch.cuda.set_device(points_device)
+    elif points.device.type == 'npu':
+        boxes[:, :, 2] += boxes[:, :, 5]
 
     ext_module.points_in_boxes_part_forward(boxes.contiguous(),
                                             points.contiguous(),

--- a/mmcv/ops/points_in_polygons.py
+++ b/mmcv/ops/points_in_polygons.py
@@ -19,6 +19,8 @@ def points_in_polygons(points: Tensor, polygons: Tensor) -> Tensor:
         polygons (torch.Tensor): It has shape (M, 8), indicating
             (x1, y1, x2, y2, x3, y3, x4, y4). M means the number of
             ground truth polygons.
+        constraints: The absolute value of input range from e-10 to
+            e10 on NPU.
 
     Returns:
         torch.Tensor: Return the result with the shape of (B, M),

--- a/mmcv/ops/points_in_polygons.py
+++ b/mmcv/ops/points_in_polygons.py
@@ -19,8 +19,8 @@ def points_in_polygons(points: Tensor, polygons: Tensor) -> Tensor:
         polygons (torch.Tensor): It has shape (M, 8), indicating
             (x1, y1, x2, y2, x3, y3, x4, y4). M means the number of
             ground truth polygons.
-        constraints: The absolute value of input range from e-10 to
-            e10 on NPU.
+        constraints: The number of significant digits for the input-arguments
+            are between -10 and 10 when running on Ascend device.
 
     Returns:
         torch.Tensor: Return the result with the shape of (B, M),

--- a/mmcv/ops/three_nn.py
+++ b/mmcv/ops/three_nn.py
@@ -34,6 +34,20 @@ class ThreeNN(Function):
 
         B, N, _ = target.size()
         m = source.size(1)
+        if source.device.type == 'npu':
+            # strict to fp32
+            source = source.transpose(2, 1).contiguous()
+            dtype_ = source.dtype
+            if dtype_ == torch.float16:
+                target = target.float()
+                source = source.float()
+            dist = target.new_empty(B, N, m)
+            ext_module.three_nn_forward(target, source, dist, torch.Tensor([]).npu(), b=B, n=N, m=m)
+            dist2, idx = torch.topk(dist, 3, dim=2, largest=False, sorted=True)
+            dist2 = torch.sqrt(dist2)
+            if dtype_ == torch.float16:
+                dist2 = dist2.half()
+            return dist2, idx.type(torch.IntTensor)
         dist2 = target.new_empty(B, N, 3)
         idx = target.new_empty(B, N, 3, dtype=torch.int32)
 

--- a/mmcv/ops/three_nn.py
+++ b/mmcv/ops/three_nn.py
@@ -42,12 +42,13 @@ class ThreeNN(Function):
                 target = target.float()
                 source = source.float()
             dist = target.new_empty(B, N, m)
-            ext_module.three_nn_forward(target, source, dist, torch.Tensor([]).npu(), b=B, n=N, m=m)
+            ext_module.three_nn_forward(
+                target, source, dist, torch.Tensor([]).npu(), b=B, n=N, m=m)
             dist2, idx = torch.topk(dist, 3, dim=2, largest=False, sorted=True)
             dist2 = torch.sqrt(dist2)
             if dtype_ == torch.float16:
                 dist2 = dist2.half()
-            return dist2, idx.type(torch.IntTensor)
+            return dist2, idx.int()
         dist2 = target.new_empty(B, N, 3)
         idx = target.new_empty(B, N, 3, dtype=torch.int32)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This PR add a dtype check for roi_align, which should only support `fp32`.
## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
